### PR TITLE
Join the Lab page overhaul with clear application CTA

### DIFF
--- a/opportunities.qmd
+++ b/opportunities.qmd
@@ -1,5 +1,5 @@
 ---
-pagetitle: "Opportunities | ECLIPSE Lab"
+pagetitle: "Join the Lab | ECLIPSE Lab"
 toc: true
 ---
 
@@ -7,21 +7,76 @@ toc: true
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="index.html">Home</a></li>
-    <li class="breadcrumb-item active" aria-current="page">Opportunities</li>
+    <li class="breadcrumb-item active" aria-current="page">Join the Lab</li>
   </ol>
 </nav>
 ```
 
-## For Undergraduate Students
-The lab is frequently home to undergraduate students from the Materials Science department(and occasionally others). 
+## Join the ECLIPSE Lab
 
-## For Prospective Graduate Students
-The [FAU Materials Science Department](https://www.fau.eu/education/degree-programmes/international-degree-programmes/degree-programmes-taught-exclusively-in-english/materials-science-and-engineering/) grants doctoral degrees in Materials Science and Engineering. Doctoral degrees in Physics can be arranged with a joint supervision. 
+We welcome motivated students and researchers who want to work on **computational imaging**, **inverse problems**, and **AI-enabled materials characterization**.
 
-Dr. Pelz advises graduate students in the **Materials Science Department** and is a particularly good match for students with interests in computational imaging, inverse problems, and computational methods in materials characterization.
+::: {.callout-tip appearance="simple"}
+### Fast track
+If this sounds like your research direction, apply now.
 
-Graduate students will receive a world-class education in the scientific method and have many opportunities to contribute to ongoing research projects.
+[**Apply to join the lab**](#application) {.btn .btn-primary}
+:::
 
+## Who should apply?
 
-## For Prospective Postdocs and Staff
-Postdoctoral fellowships and other staff positions in the lab will be made available as funding permits. Please check the [News](news.qmd) page for more information.
+You are a strong fit if you have some of the following:
+
+- Background in **materials science**, **physics**, **electrical engineering**, **computer science**, or related fields
+- Experience in one or more of:
+  - Scientific programming (Python/Julia/Matlab/C++)
+  - Optimization, inverse problems, computational imaging, or signal processing
+  - Machine learning for scientific data
+  - Electron microscopy or diffraction data analysis
+- Interest in rigorous, interdisciplinary research with real experimental relevance
+
+## Open pathways
+
+### Undergraduate students
+The lab regularly hosts undergraduate students (primarily from Materials Science, and occasionally related departments) for thesis projects and research assistant roles.
+
+### Prospective graduate students
+The [FAU Materials Science Department](https://www.fau.eu/education/degree-programmes/international-degree-programmes/degree-programmes-taught-exclusively-in-english/materials-science-and-engineering/) grants doctoral degrees in Materials Science and Engineering. Doctoral degrees in Physics can be arranged via joint supervision.
+
+Dr. Pelz advises graduate students in the **Materials Science Department**, especially in:
+
+- computational imaging
+- inverse problems
+- computational methods in materials characterization
+
+### Prospective postdocs and staff
+Postdoctoral fellowships and staff positions are opened as funding permits. Please also monitor the [News](news.qmd) page for current calls.
+
+## Application {#application}
+
+Please send one concise application email with the following:
+
+1. **CV** (max 2 pages preferred)
+2. **Transcript(s)** and degree status
+3. **Short motivation statement** (5–10 sentences):
+   - your research interests
+   - why ECLIPSE Lab
+   - what you want to work on
+4. **Optional supporting material**:
+   - GitHub/portfolio
+   - preprints/publications
+   - code or project samples
+
+### Selection timeline
+
+- **Acknowledgement:** within ~1 week
+- **Initial evaluation:** 1–3 weeks
+- **Interview / technical discussion (if shortlisted):** typically within 2–5 weeks
+- **Final decision:** timing depends on position type and funding cycle
+
+## Contact
+
+For applications and position-related inquiries:
+
+- [Contact Dr. Pelz](contact.qmd)
+- Or email with subject line: `Application – [Your Name] – [Level: UG/PhD/Postdoc]`


### PR DESCRIPTION
## Summary
- rename Opportunities framing to a clear "Join the Lab" recruiting page
- add an above-the-fold application CTA button and anchor section
- define candidate fit (background + skills) to improve applicant quality
- add an explicit application checklist and expected selection timeline
- keep pathways for undergraduate, graduate, and postdoc/staff applicants
- add clear contact paths to reduce friction for inbound applications

## Why
This converts a generic opportunities description into an actionable recruiting funnel with concrete next steps for applicants.

## Scope
- opportunities.qmd

## Validation
- content and structure reviewed for clarity and completeness
- no build-system or dependency changes
