### PR TITLE
Website: improve homepage storytelling, research page, and footer clarity

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -59,10 +59,10 @@ website:
     center: 
       - text: "Imprint"
         href: about.qmd
-      - text: "Privacy"
-        href: license.html
-      - text: "Accessibility"
-        href: trademark.html
+      - text: "Privacy Notice"
+        href: license.qmd
+      - text: "Accessibility Statement"
+        href: trademark.qmd
   # cookie-consent:
   #   type: express
   #   style: headline

--- a/about.qmd
+++ b/about.qmd
@@ -1,5 +1,9 @@
 ---
-title: "About"
+title: "Imprint"
 ---
 
-About this site
+## Imprint
+
+This website presents the ECLIPSE Lab and related research, teaching, and opportunity information.
+
+For official institutional and contact details, please use the [Contact](contact.qmd) page and the relevant Friedrich-Alexander University Erlangen-Nürnberg resources.

--- a/docs/about.html
+++ b/docs/about.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 
-<title>About – ECLIPSE Lab</title>
+<title>Imprint – ECLIPSE Lab</title>
 <style>
 code{white-space: pre-wrap;}
 span.smallcaps{font-variant: small-caps;}
@@ -81,13 +81,19 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 
 
 <link rel="stylesheet" href="styles.css">
-<meta property="og:title" content="About – ECLIPSE Lab">
+<meta property="og:title" content="Imprint – ECLIPSE Lab">
 <meta property="og:description" content="">
+<meta property="og:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta property="og:site_name" content="ECLIPSE Lab">
-<meta name="twitter:title" content="About – ECLIPSE Lab">
+<meta property="og:image:height" content="554">
+<meta property="og:image:width" content="1080">
+<meta name="twitter:title" content="Imprint – ECLIPSE Lab">
 <meta name="twitter:description" content="">
+<meta name="twitter:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta name="twitter:creator" content="@PhilippPelz">
-<meta name="twitter:card" content="summary">
+<meta name="twitter:image-height" content="554">
+<meta name="twitter:image-width" content="1080">
+<meta name="twitter:card" content="summary_large_image">
 </head>
 
 <body class="nav-fixed quarto-light">
@@ -132,6 +138,10 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 <span class="menu-text">Research</span></a>
   </li>  
   <li class="nav-item">
+    <a class="nav-link" href="./research-by-problem.html"> 
+<span class="menu-text">By Problem</span></a>
+  </li>  
+  <li class="nav-item">
     <a class="nav-link" href="./publications.html"> 
 <span class="menu-text">Publications</span></a>
   </li>  
@@ -170,15 +180,21 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 <div id="quarto-content" class="quarto-container page-columns page-rows-contents page-layout-article page-navbar">
 <!-- sidebar -->
 <!-- margin-sidebar -->
-    <div id="quarto-margin-sidebar" class="sidebar margin-sidebar zindex-bottom">
-        
+    <div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
+        <nav id="TOC" role="doc-toc" class="toc-active">
+    <h2 id="toc-title">On this page</h2>
+   
+  <ul>
+  <li><a href="#imprint" id="toc-imprint" class="nav-link active" data-scroll-target="#imprint">Imprint</a></li>
+  </ul>
+<div class="toc-actions"><ul><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/blob/main/about.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></nav>
     </div>
 <!-- main -->
 <main class="content" id="quarto-document-content">
 
 <header id="title-block-header" class="quarto-title-block default">
 <div class="quarto-title">
-<h1 class="title">About</h1>
+<h1 class="title">Imprint</h1>
 </div>
 
 
@@ -195,9 +211,13 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 </header>
 
 
-<p>About this site</p>
+<section id="imprint" class="level2">
+<h2 class="anchored" data-anchor-id="imprint">Imprint</h2>
+<p>This website presents the ECLIPSE Lab and related research, teaching, and opportunity information.</p>
+<p>For official institutional and contact details, please use the <a href="./contact.html">Contact</a> page and the relevant Friedrich-Alexander University Erlangen-Nürnberg resources.</p>
 
 
+</section>
 
 </main> <!-- /main -->
 <script id="quarto-html-after-body" type="application/javascript">
@@ -615,16 +635,16 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   </li>  
     <li class="nav-item">
     <a class="nav-link" href="./license.html">
-<p>Privacy</p>
+<p>Privacy Notice</p>
 </a>
   </li>  
     <li class="nav-item">
     <a class="nav-link" href="./trademark.html">
-<p>Accessibility</p>
+<p>Accessibility Statement</p>
 </a>
   </li>  
 </ul>
-    </div>
+    <div class="toc-actions d-sm-block d-md-none"><ul><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/blob/main/about.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></div>
     <div class="nav-footer-right">
       &nbsp;
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,12 +82,14 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 
 <link rel="stylesheet" href="styles.css">
 <meta property="og:title" content="ECLIPSE Lab">
+<meta property="og:description" content="">
 <meta property="og:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta property="og:site_name" content="ECLIPSE Lab">
 <meta property="og:image:alt" content="ECLIPSE Lab">
 <meta property="og:image:height" content="554">
 <meta property="og:image:width" content="1080">
 <meta name="twitter:title" content="ECLIPSE Lab">
+<meta name="twitter:description" content="">
 <meta name="twitter:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta name="twitter:creator" content="@PhilippPelz">
 <meta name="twitter:image-height" content="554">
@@ -192,6 +194,30 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 <div class="hero2">
 <p>We develop computational tools to enable new capabilities in electron and X-ray microscopes and apply them to challenging materials science questions.</p>
 </div>
+<section id="start-here" class="level2">
+<h2 class="anchored" data-anchor-id="start-here">Start here</h2>
+<p>If you are new to the lab, the shortest useful summary is this: we work on difficult imaging problems where better reconstruction, automation, and physically informed computation can unlock new scientific measurements.</p>
+<div class="columns">
+<div class="column" style="width:33%;">
+<section id="what-problem-are-we-solving" class="level3">
+<h3 class="anchored" data-anchor-id="what-problem-are-we-solving">What problem are we solving?</h3>
+<p>Modern microscopy often produces rich but difficult-to-interpret measurements. We develop methods that make 3D structure, chemistry, and weak signals more accessible at higher throughput and lower dose.</p>
+<p><a href="./research-by-problem.html" class="btn btn-primary">See research by problem</a></p>
+</section>
+</div><div class="column" style="width:33%;">
+<section id="why-does-it-matter-now" class="level3">
+<h3 class="anchored" data-anchor-id="why-does-it-matter-now">Why does it matter now?</h3>
+<p>Better algorithms and automation make it possible to extract more information from advanced microscopes while improving speed, sensitivity, and experimental reliability.</p>
+<p><a href="./research.html" class="btn btn-primary">Explore research directions</a></p>
+</section>
+</div><div class="column" style="width:34%;">
+<section id="where-should-i-go-next" class="level3">
+<h3 class="anchored" data-anchor-id="where-should-i-go-next">Where should I go next?</h3>
+<p>Whether you want to join the lab, collaborate on a project, or understand our current work, start with the pathways below.</p>
+<p><a href="./opportunities.html" class="btn btn-primary me-1">Join the lab</a> <a href="./contact.html" class="btn btn-outline-secondary">Contact us</a></p>
+</section>
+</div>
+</div>
 <div class="lead">
 <p>Publication Highlights</p>
 </div>
@@ -239,7 +265,7 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
         <div>
           <a href="https://www.nature.com/articles/s41467-023-39304-9">Imaging the electron charge density in monolayer MoS2 at the Angstrom scale (Nat Comm 2023)</a>
                 </div>
-        <img src="img/charge_density.svg" alt="c">
+        <img src="img/charge_density.svg" alt="Imaging the electron charge density in monolayer MoS2 at the Angstrom scale">
       </li>
 
         </ul>
@@ -309,6 +335,7 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 </div>
 
 
+</section>
 
 </main> <!-- /main -->
 <script id="quarto-html-after-body" type="application/javascript">
@@ -726,12 +753,12 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   </li>  
     <li class="nav-item">
     <a class="nav-link" href="./license.html">
-<p>Privacy</p>
+<p>Privacy Notice</p>
 </a>
   </li>  
     <li class="nav-item">
     <a class="nav-link" href="./trademark.html">
-<p>Accessibility</p>
+<p>Accessibility Statement</p>
 </a>
   </li>  
 </ul>

--- a/docs/license.html
+++ b/docs/license.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 
-<title>Accessibility – ECLIPSE Lab</title>
+<title>Privacy – ECLIPSE Lab</title>
 <style>
 code{white-space: pre-wrap;}
 span.smallcaps{font-variant: small-caps;}
@@ -83,11 +83,17 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 <link rel="stylesheet" href="styles.css">
 <meta property="og:title" content="Privacy – ECLIPSE Lab">
 <meta property="og:description" content="">
+<meta property="og:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta property="og:site_name" content="ECLIPSE Lab">
+<meta property="og:image:height" content="554">
+<meta property="og:image:width" content="1080">
 <meta name="twitter:title" content="Privacy – ECLIPSE Lab">
 <meta name="twitter:description" content="">
+<meta name="twitter:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta name="twitter:creator" content="@PhilippPelz">
-<meta name="twitter:card" content="summary">
+<meta name="twitter:image-height" content="554">
+<meta name="twitter:image-width" content="1080">
+<meta name="twitter:card" content="summary_large_image">
 </head>
 
 <body class="nav-fixed quarto-light">
@@ -130,6 +136,10 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   <li class="nav-item">
     <a class="nav-link" href="./research.html"> 
 <span class="menu-text">Research</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="./research-by-problem.html"> 
+<span class="menu-text">By Problem</span></a>
   </li>  
   <li class="nav-item">
     <a class="nav-link" href="./publications.html"> 
@@ -181,21 +191,15 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   <li><a href="#what-we-do-not-do" id="toc-what-we-do-not-do" class="nav-link" data-scroll-target="#what-we-do-not-do">What we do not do</a></li>
   <li><a href="#contact" id="toc-contact" class="nav-link" data-scroll-target="#contact">Contact</a></li>
   </ul></li>
-  <li><a href="#accessibility-statement" id="toc-accessibility-statement" class="nav-link" data-scroll-target="#accessibility-statement">Accessibility Statement</a>
-  <ul class="collapse">
-  <li><a href="#our-goals" id="toc-our-goals" class="nav-link" data-scroll-target="#our-goals">Our goals</a></li>
-  <li><a href="#known-limitations" id="toc-known-limitations" class="nav-link" data-scroll-target="#known-limitations">Known limitations</a></li>
-  <li><a href="#feedback" id="toc-feedback" class="nav-link" data-scroll-target="#feedback">Feedback</a></li>
-  </ul></li>
   </ul>
-</nav>
+<div class="toc-actions"><ul><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/blob/main/license.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></nav>
     </div>
 <!-- main -->
 <main class="content" id="quarto-document-content">
 
 <header id="title-block-header" class="quarto-title-block default">
 <div class="quarto-title">
-<h1 class="title">Accessibility</h1>
+<h1 class="title">Privacy</h1>
 </div>
 
 
@@ -219,7 +223,7 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 <h3 class="anchored" data-anchor-id="what-we-collect">What we collect</h3>
 <ul>
 <li>Basic aggregated website analytics (Google Analytics) to understand overall site usage.</li>
-<li>Information you voluntarily provide when contacting us (e.g., by email).</li>
+<li>Information you voluntarily provide when contacting us (for example by email).</li>
 </ul>
 </section>
 <section id="what-we-do-not-do" class="level3">
@@ -234,26 +238,6 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 <p>If you have privacy questions, please use the contact details on the <a href="./contact.html">Contact</a> page.</p>
 
 
-</section>
-</section>
-<section id="accessibility-statement" class="level2">
-<h2 class="anchored" data-anchor-id="accessibility-statement">Accessibility Statement</h2>
-<p>ECLIPSE Lab aims to make this website accessible and usable for all visitors.</p>
-<section id="our-goals" class="level3">
-<h3 class="anchored" data-anchor-id="our-goals">Our goals</h3>
-<ul>
-<li>Clear page structure and headings</li>
-<li>Readable contrast and typography</li>
-<li>Keyboard-friendly navigation where possible</li>
-</ul>
-</section>
-<section id="known-limitations" class="level3">
-<h3 class="anchored" data-anchor-id="known-limitations">Known limitations</h3>
-<p>Some legacy content and embedded media may not fully meet current accessibility best practices.</p>
-</section>
-<section id="feedback" class="level3">
-<h3 class="anchored" data-anchor-id="feedback">Feedback</h3>
-<p>If you encounter an accessibility barrier, please let us know via the <a href="./contact.html">Contact</a> page so we can improve the site.</p>
 </section>
 </section>
 
@@ -673,16 +657,16 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   </li>  
     <li class="nav-item">
     <a class="nav-link active" href="./license.html" aria-current="page">
-<p>Privacy</p>
+<p>Privacy Notice</p>
 </a>
   </li>  
     <li class="nav-item">
     <a class="nav-link" href="./trademark.html">
-<p>Accessibility</p>
+<p>Accessibility Statement</p>
 </a>
   </li>  
 </ul>
-    </div>
+    <div class="toc-actions d-sm-block d-md-none"><ul><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/blob/main/license.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></div>
     <div class="nav-footer-right">
       &nbsp;
     </div>

--- a/docs/research.html
+++ b/docs/research.html
@@ -82,10 +82,18 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 
 <link rel="stylesheet" href="styles.css">
 <meta property="og:title" content="Research | ECLIPSE Lab">
+<meta property="og:description" content="">
+<meta property="og:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta property="og:site_name" content="ECLIPSE Lab">
+<meta property="og:image:height" content="554">
+<meta property="og:image:width" content="1080">
 <meta name="twitter:title" content="Research | ECLIPSE Lab">
+<meta name="twitter:description" content="">
+<meta name="twitter:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta name="twitter:creator" content="@PhilippPelz">
-<meta name="twitter:card" content="summary">
+<meta name="twitter:image-height" content="554">
+<meta name="twitter:image-width" content="1080">
+<meta name="twitter:card" content="summary_large_image">
 </head>
 
 <body class="nav-fixed quarto-light">
@@ -128,6 +136,10 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   <li class="nav-item">
     <a class="nav-link active" href="./research.html" aria-current="page"> 
 <span class="menu-text">Research</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="./research-by-problem.html"> 
+<span class="menu-text">By Problem</span></a>
   </li>  
   <li class="nav-item">
     <a class="nav-link" href="./publications.html"> 
@@ -173,11 +185,13 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
     <h2 id="toc-title">On this page</h2>
    
   <ul>
-  <li><a href="#research-topics" id="toc-research-topics" class="nav-link active" data-scroll-target="#research-topics">Research Topics</a>
+  <li><a href="#research" id="toc-research" class="nav-link active" data-scroll-target="#research">Research</a></li>
+  <li><a href="#capability-areas" id="toc-capability-areas" class="nav-link" data-scroll-target="#capability-areas">Capability areas</a>
   <ul class="collapse">
-  <li><a href="#computational-imaging" id="toc-computational-imaging" class="nav-link" data-scroll-target="#computational-imaging">Computational imaging</a></li>
+  <li><a href="#computational-imaging-for-difficult-3d-measurements" id="toc-computational-imaging-for-difficult-3d-measurements" class="nav-link" data-scroll-target="#computational-imaging-for-difficult-3d-measurements">Computational imaging for difficult 3D measurements</a></li>
+  <li><a href="#fast-simulation-and-model-based-electron-microscopy" id="toc-fast-simulation-and-model-based-electron-microscopy" class="nav-link" data-scroll-target="#fast-simulation-and-model-based-electron-microscopy">Fast simulation and model-based electron microscopy</a></li>
   <li><a href="#multi-modal-microscopy" id="toc-multi-modal-microscopy" class="nav-link" data-scroll-target="#multi-modal-microscopy">Multi-modal microscopy</a></li>
-  <li><a href="#self-driving-equipment" id="toc-self-driving-equipment" class="nav-link" data-scroll-target="#self-driving-equipment">Self-driving equipment</a></li>
+  <li><a href="#self-driving-and-automated-microscopy" id="toc-self-driving-and-automated-microscopy" class="nav-link" data-scroll-target="#self-driving-and-automated-microscopy">Self-driving and automated microscopy</a></li>
   </ul></li>
   <li><a href="#research-funding" id="toc-research-funding" class="nav-link" data-scroll-target="#research-funding">Research Funding</a>
   <ul class="collapse">
@@ -186,11 +200,11 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   </ul></li>
   <li><a href="#research-framework" id="toc-research-framework" class="nav-link" data-scroll-target="#research-framework">Research Framework</a>
   <ul class="collapse">
-  <li><a href="#holistic-microscopy---using-as-much-of-the-scattering-information-as-possible" id="toc-holistic-microscopy---using-as-much-of-the-scattering-information-as-possible" class="nav-link" data-scroll-target="#holistic-microscopy---using-as-much-of-the-scattering-information-as-possible">Holistic microscopy - using as much of the scattering information as possible</a></li>
+  <li><a href="#holistic-microscopy" id="toc-holistic-microscopy" class="nav-link" data-scroll-target="#holistic-microscopy">Holistic microscopy</a></li>
   <li><a href="#ml-driven-microscopy" id="toc-ml-driven-microscopy" class="nav-link" data-scroll-target="#ml-driven-microscopy">ML-driven microscopy</a></li>
   </ul></li>
   </ul>
-</nav>
+<div class="toc-actions"><ul><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/blob/main/research.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></nav>
     </div>
 <!-- main -->
 <main class="content" id="quarto-document-content"><header id="title-block-header" class="quarto-title-block"></header>
@@ -204,37 +218,52 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
     <li class="breadcrumb-item active" aria-current="page">Research</li>
   </ol>
 </nav>
-<section id="research-topics" class="level2">
-<h2 class="anchored" data-anchor-id="research-topics">Research Topics</h2>
-<section id="computational-imaging" class="level3">
-<h3 class="anchored" data-anchor-id="computational-imaging">Computational imaging</h3>
-<ul>
-<li><p><strong>Large-scale dose-efficient 3D imaging</strong></p>
-<p>We are leaders in the development of 3D imaging methods based on 4D-STEM measurements.</p>
-<ul>
-<li><a href="https://www.nature.com/articles/s41467-023-43634-z">2023: first atomic-resolution 3D volume from 4D-STEM tomography</a></li>
-<li><a href="https://doi.org/10.1088/2515-7639/ad9ad2">2024: first atomic-resolution phase-contrast volume beyond the depth of focus limit</a></li>
-<li><a href="https://doi.org/10.1088/1402-4896/ad9a1a">2024: first end-to-end reconstruction reaching sub-Angstrom resolution</a></li>
-</ul>
-<p>These methods will enable high-throughput, high-resolution, and high-sensitivity 3D imaging of large samples. Especially weakly scattering atoms can be resolved with unprecedented accuracy.</p></li>
-<li><p><strong>Fast simulators for electron microscopy</strong></p>
-<p>We are developing fast simulators for electron microscopy.</p>
-<ul>
-<li><a href="https://academic.oup.com/mam/article/27/4/835/6888048">&gt;100x faster simulations</a></li>
-</ul></li>
-</ul>
+<section id="research" class="level2">
+<h2 class="anchored" data-anchor-id="research">Research</h2>
+<p>Prefer a problem-first view? See <a href="./research-by-problem.html">Research by Problem</a>.</p>
+</section>
+<section id="capability-areas" class="level2">
+<h2 class="anchored" data-anchor-id="capability-areas">Capability areas</h2>
+<section id="computational-imaging-for-difficult-3d-measurements" class="level3">
+<h3 class="anchored" data-anchor-id="computational-imaging-for-difficult-3d-measurements">Computational imaging for difficult 3D measurements</h3>
+<p><strong>What we build</strong><br>
+We develop 3D imaging methods based on 4D-STEM and related computational reconstruction pipelines for large-scale, dose-efficient, high-resolution measurements.</p>
+<p><strong>Why it matters</strong><br>
+Many important materials problems require 3D information at high resolution, but conventional workflows remain too slow, too dose-intensive, or too limited for weakly scattering structures.</p>
+<p><strong>Representative results</strong> - <a href="https://www.nature.com/articles/s41467-023-43634-z">2023: first atomic-resolution 3D volume from 4D-STEM tomography</a> - <a href="https://doi.org/10.1088/2515-7639/ad9ad2">2024: first atomic-resolution phase-contrast volume beyond the depth of focus limit</a> - <a href="https://doi.org/10.1088/1402-4896/ad9a1a">2024: first end-to-end reconstruction reaching sub-Angstrom resolution</a></p>
+<p><strong>Collaboration angle</strong><br>
+We are interested in collaborations where new reconstruction methods can unlock 3D structure, chemistry, or sensitivity in experimentally challenging datasets.</p>
+</section>
+<section id="fast-simulation-and-model-based-electron-microscopy" class="level3">
+<h3 class="anchored" data-anchor-id="fast-simulation-and-model-based-electron-microscopy">Fast simulation and model-based electron microscopy</h3>
+<p><strong>What we build</strong><br>
+We develop fast simulators and model-based workflows for electron microscopy that support method design, reconstruction, and quantitative interpretation.</p>
+<p><strong>Why it matters</strong><br>
+Simulation is essential for testing algorithms, understanding signal formation, and scaling new microscopy methods to realistic experiments.</p>
+<p><strong>Representative result</strong> - <a href="https://academic.oup.com/mam/article/27/4/835/6888048">&gt;100x faster simulations</a></p>
+<p><strong>Collaboration angle</strong><br>
+This is relevant for groups who need reliable forward models, synthetic benchmarks, or tighter coupling between experiment and computation.</p>
 </section>
 <section id="multi-modal-microscopy" class="level3">
 <h3 class="anchored" data-anchor-id="multi-modal-microscopy">Multi-modal microscopy</h3>
-<p>We are developing new approaches for multi-modal 3D imaging, down to the atomic scale.</p>
-<p>Stay tuned for the first results!</p>
+<p><strong>What we build</strong><br>
+We are developing new approaches for multi-modal 3D imaging, down to the atomic scale.</p>
+<p><strong>Why it matters</strong><br>
+Combining complementary signals can reveal structure, chemistry, and function more effectively than single-mode imaging alone.</p>
+<p><strong>Current status</strong><br>
+Stay tuned for the first results.</p>
+<p><strong>Collaboration angle</strong><br>
+We welcome collaborations where multimodal data fusion or cross-signal interpretation is the limiting step.</p>
 </section>
-<section id="self-driving-equipment" class="level3">
-<h3 class="anchored" data-anchor-id="self-driving-equipment">Self-driving equipment</h3>
-<p>We are developing automation methods for electron microscopy.</p>
-<ul>
-<li><a href="https://doi.org/10.1093/mam/ozaf048.070">Automated End-to-end ptychographic tomography</a></li>
-</ul>
+<section id="self-driving-and-automated-microscopy" class="level3">
+<h3 class="anchored" data-anchor-id="self-driving-and-automated-microscopy">Self-driving and automated microscopy</h3>
+<p><strong>What we build</strong><br>
+We develop automation methods for electron microscopy, including end-to-end and self-driving workflows.</p>
+<p><strong>Why it matters</strong><br>
+Automation reduces friction in advanced experiments, improves repeatability, and enables higher-throughput scientific discovery.</p>
+<p><strong>Representative result</strong> - <a href="https://doi.org/10.1093/mam/ozaf048.070">Automated end-to-end ptychographic tomography</a></p>
+<p><strong>Collaboration angle</strong><br>
+This is particularly relevant for partners who want more robust acquisition, scalable pipelines, or autonomous microscopy workflows.</p>
 </section>
 </section>
 <section id="research-funding" class="level2">
@@ -275,13 +304,13 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 </section>
 <section id="research-framework" class="level2">
 <h2 class="anchored" data-anchor-id="research-framework">Research Framework</h2>
-<section id="holistic-microscopy---using-as-much-of-the-scattering-information-as-possible" class="level3">
-<h3 class="anchored" data-anchor-id="holistic-microscopy---using-as-much-of-the-scattering-information-as-possible">Holistic microscopy - using as much of the scattering information as possible</h3>
-<p>The substantive focus of our work is on incorporating prior physical knowledge about scattering mechanisms and multiple signal channels into the image reconstruction.</p>
+<section id="holistic-microscopy" class="level3">
+<h3 class="anchored" data-anchor-id="holistic-microscopy">Holistic microscopy</h3>
+<p>The substantive focus of our work is on incorporating prior physical knowledge about scattering mechanisms and multiple signal channels into image reconstruction.</p>
 </section>
 <section id="ml-driven-microscopy" class="level3">
 <h3 class="anchored" data-anchor-id="ml-driven-microscopy">ML-driven microscopy</h3>
-<p>We use modern machine learning tools to make microscopy faster and better</p>
+<p>We use modern machine learning tools to make microscopy faster, more robust, and more informative.</p>
 
 
 </section>
@@ -703,16 +732,16 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   </li>  
     <li class="nav-item">
     <a class="nav-link" href="./license.html">
-<p>Privacy</p>
+<p>Privacy Notice</p>
 </a>
   </li>  
     <li class="nav-item">
     <a class="nav-link" href="./trademark.html">
-<p>Accessibility</p>
+<p>Accessibility Statement</p>
 </a>
   </li>  
 </ul>
-    </div>
+    <div class="toc-actions d-sm-block d-md-none"><ul><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/blob/main/research.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></div>
     <div class="nav-footer-right">
       &nbsp;
     </div>

--- a/docs/search.json
+++ b/docs/search.json
@@ -25,7 +25,7 @@
     "href": "research.html#research-framework",
     "title": "ECLIPSE Lab",
     "section": "Research Framework",
-    "text": "Research Framework\n\nHolistic microscopy - using as much of the scattering information as possible\nThe substantive focus of our work is on incorporating prior physical knowledge about scattering mechanisms and multiple signal channels into the image reconstruction.\n\n\nML-driven microscopy\nWe use modern machine learning tools to make microscopy faster and better"
+    "text": "Research Framework\n\nHolistic microscopy\nThe substantive focus of our work is on incorporating prior physical knowledge about scattering mechanisms and multiple signal channels into image reconstruction.\n\n\nML-driven microscopy\nWe use modern machine learning tools to make microscopy faster, more robust, and more informative."
   },
   {
     "objectID": "contact.html",
@@ -382,7 +382,7 @@
     "href": "index.html",
     "title": "ECLIPSE Lab",
     "section": "",
-    "text": "Welcome to the     \n\n\nWe develop computational tools to enable new capabilities in electron and X-ray microscopes and apply them to challenging materials science questions.\n\n\nPublication Highlights\n\n\n\n\n  \n        \n      \n        \n          New Resolution Record in 3D Phase-Contrast Imaging\n (Phys Scripta 2024)\n                    \n                \n        \n          \n          \n          \n        \n      \n      \n        \n          Solving Complex Nanostructures With Ptychographic Atomic Electron Tomography\n (Nat Comm 2023)\n                    \n                \n        \n          \n          \n          \n        \n      \n\n            \n        \n          Simultaneous Successive Twinning Captured by Atomic Electron Tomography (ACS Nano 2021)\n                \n        \n          \n          \n          \n        \n      \n      \n        \n          Imaging the electron charge density in monolayer MoS2 at the Angstrom scale (Nat Comm 2023)\n                \n        \n      \n\n        \n  \n  \n        \n        \n  \n\n\n\n\nWe are an interdisciplinary research group based within the Department of Materials Science at the Friedrich-Alexander University of Erlangen-Nürnberg. We have expertise in condensed matter physics, deep learning, large-scale optimization, signal and image processing, and experimental design for advanced X-ray and electron microscopy experiments.\nWe are part of the Institute of Micro- and Nanostructure Research and the Center for Nanoanalysis and Electron Microscopy and part of the Competence Unit Engineering of Advanced Materials.\n\n\nHow can we help you today?\n\n\n\n\nProspective students & researchers\nLearn about open positions, projects, and how to join the lab.\n\nMSc and PhD theses\nPostdoctoral positions\nShort-term research projects\n\nSee open opportunities\n\n\n\nCollaborators & facilities\nSee our research directions and how we work with partners.\n\nAdvanced electron and X-ray microscopy\nMethod development and software\nAccess to instrumentation and expertise\n\nSee research themes Browse resources\n\n\n\nWhat’s new?\nTalks, awards, and other recent lab news.\n\nRecent talks and workshops\nGrants, awards, and recognitions\nNew people and projects\n\nRead lab news"
+    "text": "Welcome to the"
   },
   {
     "objectID": "hyperscale.html",
@@ -758,9 +758,9 @@
   {
     "objectID": "about.html",
     "href": "about.html",
-    "title": "About",
+    "title": "Imprint",
     "section": "",
-    "text": "About this site"
+    "text": "This website presents the ECLIPSE Lab and related research, teaching, and opportunity information.\nFor official institutional and contact details, please use the Contact page and the relevant Friedrich-Alexander University Erlangen-Nürnberg resources."
   },
   {
     "objectID": "people/staff/00_pelz_philipp.html",
@@ -1143,16 +1143,16 @@
   {
     "objectID": "license.html",
     "href": "license.html",
-    "title": "Accessibility",
+    "title": "Privacy",
     "section": "",
-    "text": "ECLIPSE Lab is committed to collecting as little personal data as possible.\n\n\n\nBasic aggregated website analytics (Google Analytics) to understand overall site usage.\nInformation you voluntarily provide when contacting us (e.g., by email).\n\n\n\n\n\nWe do not sell personal data.\nWe do not use advertising trackers.\n\n\n\n\nIf you have privacy questions, please use the contact details on the Contact page."
+    "text": "ECLIPSE Lab is committed to collecting as little personal data as possible.\n\n\n\nBasic aggregated website analytics (Google Analytics) to understand overall site usage.\nInformation you voluntarily provide when contacting us (for example by email).\n\n\n\n\n\nWe do not sell personal data.\nWe do not use advertising trackers.\n\n\n\n\nIf you have privacy questions, please use the contact details on the Contact page."
   },
   {
     "objectID": "license.html#privacy-notice",
     "href": "license.html#privacy-notice",
-    "title": "Accessibility",
+    "title": "Privacy",
     "section": "",
-    "text": "ECLIPSE Lab is committed to collecting as little personal data as possible.\n\n\n\nBasic aggregated website analytics (Google Analytics) to understand overall site usage.\nInformation you voluntarily provide when contacting us (e.g., by email).\n\n\n\n\n\nWe do not sell personal data.\nWe do not use advertising trackers.\n\n\n\n\nIf you have privacy questions, please use the contact details on the Contact page."
+    "text": "ECLIPSE Lab is committed to collecting as little personal data as possible.\n\n\n\nBasic aggregated website analytics (Google Analytics) to understand overall site usage.\nInformation you voluntarily provide when contacting us (for example by email).\n\n\n\n\n\nWe do not sell personal data.\nWe do not use advertising trackers.\n\n\n\n\nIf you have privacy questions, please use the contact details on the Contact page."
   },
   {
     "objectID": "license.html#accessibility-statement",
@@ -1166,14 +1166,14 @@
     "href": "trademark.html",
     "title": "Accessibility",
     "section": "",
-    "text": "ECLIPSE Lab aims to make this website accessible and usable for all visitors.\n\n\n\nClear page structure and headings\nReadable contrast and typography\nKeyboard-friendly navigation where possible\n\n\n\n\nSome legacy content and embedded media may not fully meet current accessibility best practices.\n\n\n\nIf you encounter an accessibility barrier, please let us know via the Contact page so we can improve the site."
+    "text": "ECLIPSE Lab aims to make this website accessible and usable for all visitors.\n\n\n\nClear page structure and headings\nReadable contrast and typography\nKeyboard-friendly navigation where possible\n\n\n\n\nSome legacy content and embedded media may not yet fully meet current accessibility best practices.\n\n\n\nIf you encounter an accessibility barrier, please let us know via the Contact page so we can improve the site."
   },
   {
     "objectID": "trademark.html#accessibility-statement",
     "href": "trademark.html#accessibility-statement",
     "title": "Accessibility",
     "section": "",
-    "text": "ECLIPSE Lab aims to make this website accessible and usable for all visitors.\n\n\n\nClear page structure and headings\nReadable contrast and typography\nKeyboard-friendly navigation where possible\n\n\n\n\nSome legacy content and embedded media may not fully meet current accessibility best practices.\n\n\n\nIf you encounter an accessibility barrier, please let us know via the Contact page so we can improve the site."
+    "text": "ECLIPSE Lab aims to make this website accessible and usable for all visitors.\n\n\n\nClear page structure and headings\nReadable contrast and typography\nKeyboard-friendly navigation where possible\n\n\n\n\nSome legacy content and embedded media may not yet fully meet current accessibility best practices.\n\n\n\nIf you encounter an accessibility barrier, please let us know via the Contact page so we can improve the site."
   },
   {
     "objectID": "news.html#news-highlights",
@@ -1195,5 +1195,33 @@
     "title": "ECLIPSE Lab",
     "section": "Recent updates",
     "text": "Recent updates\nBelow is the reverse-chronological archive of recent news items."
+  },
+  {
+    "objectID": "index.html#start-here",
+    "href": "index.html#start-here",
+    "title": "ECLIPSE Lab",
+    "section": "Start here",
+    "text": "Start here\nIf you are new to the lab, the shortest useful summary is this: we work on difficult imaging problems where better reconstruction, automation, and physically informed computation can unlock new scientific measurements.\n\n\n\nWhat problem are we solving?\nModern microscopy often produces rich but difficult-to-interpret measurements. We develop methods that make 3D structure, chemistry, and weak signals more accessible at higher throughput and lower dose.\nSee research by problem\n\n\n\nWhy does it matter now?\nBetter algorithms and automation make it possible to extract more information from advanced microscopes while improving speed, sensitivity, and experimental reliability.\nExplore research directions\n\n\n\nWhere should I go next?\nWhether you want to join the lab, collaborate on a project, or understand our current work, start with the pathways below.\nJoin the lab Contact us\n\n\n\n\nPublication Highlights\n\n\n\n\n  \n        \n      \n        \n          New Resolution Record in 3D Phase-Contrast Imaging\n (Phys Scripta 2024)\n                    \n                \n        \n          \n          \n          \n        \n      \n      \n        \n          Solving Complex Nanostructures With Ptychographic Atomic Electron Tomography\n (Nat Comm 2023)\n                    \n                \n        \n          \n          \n          \n        \n      \n\n            \n        \n          Simultaneous Successive Twinning Captured by Atomic Electron Tomography (ACS Nano 2021)\n                \n        \n          \n          \n          \n        \n      \n      \n        \n          Imaging the electron charge density in monolayer MoS2 at the Angstrom scale (Nat Comm 2023)\n                \n        \n      \n\n        \n  \n  \n        \n        \n  \n\n\n\n\nWe are an interdisciplinary research group based within the Department of Materials Science at the Friedrich-Alexander University of Erlangen-Nürnberg. We have expertise in condensed matter physics, deep learning, large-scale optimization, signal and image processing, and experimental design for advanced X-ray and electron microscopy experiments.\nWe are part of the Institute of Micro- and Nanostructure Research and the Center for Nanoanalysis and Electron Microscopy and part of the Competence Unit Engineering of Advanced Materials.\n\n\nHow can we help you today?\n\n\n\n\nProspective students & researchers\nLearn about open positions, projects, and how to join the lab.\n\nMSc and PhD theses\nPostdoctoral positions\nShort-term research projects\n\nSee open opportunities\n\n\n\nCollaborators & facilities\nSee our research directions and how we work with partners.\n\nAdvanced electron and X-ray microscopy\nMethod development and software\nAccess to instrumentation and expertise\n\nSee research themes Browse resources\n\n\n\nWhat’s new?\nTalks, awards, and other recent lab news.\n\nRecent talks and workshops\nGrants, awards, and recognitions\nNew people and projects\n\nRead lab news"
+  },
+  {
+    "objectID": "research.html#research",
+    "href": "research.html#research",
+    "title": "ECLIPSE Lab",
+    "section": "Research",
+    "text": "Research\nPrefer a problem-first view? See Research by Problem."
+  },
+  {
+    "objectID": "research.html#capability-areas",
+    "href": "research.html#capability-areas",
+    "title": "ECLIPSE Lab",
+    "section": "Capability areas",
+    "text": "Capability areas\n\nComputational imaging for difficult 3D measurements\nWhat we build\nWe develop 3D imaging methods based on 4D-STEM and related computational reconstruction pipelines for large-scale, dose-efficient, high-resolution measurements.\nWhy it matters\nMany important materials problems require 3D information at high resolution, but conventional workflows remain too slow, too dose-intensive, or too limited for weakly scattering structures.\nRepresentative results - 2023: first atomic-resolution 3D volume from 4D-STEM tomography - 2024: first atomic-resolution phase-contrast volume beyond the depth of focus limit - 2024: first end-to-end reconstruction reaching sub-Angstrom resolution\nCollaboration angle\nWe are interested in collaborations where new reconstruction methods can unlock 3D structure, chemistry, or sensitivity in experimentally challenging datasets.\n\n\nFast simulation and model-based electron microscopy\nWhat we build\nWe develop fast simulators and model-based workflows for electron microscopy that support method design, reconstruction, and quantitative interpretation.\nWhy it matters\nSimulation is essential for testing algorithms, understanding signal formation, and scaling new microscopy methods to realistic experiments.\nRepresentative result - &gt;100x faster simulations\nCollaboration angle\nThis is relevant for groups who need reliable forward models, synthetic benchmarks, or tighter coupling between experiment and computation.\n\n\nMulti-modal microscopy\nWhat we build\nWe are developing new approaches for multi-modal 3D imaging, down to the atomic scale.\nWhy it matters\nCombining complementary signals can reveal structure, chemistry, and function more effectively than single-mode imaging alone.\nCurrent status\nStay tuned for the first results.\nCollaboration angle\nWe welcome collaborations where multimodal data fusion or cross-signal interpretation is the limiting step.\n\n\nSelf-driving and automated microscopy\nWhat we build\nWe develop automation methods for electron microscopy, including end-to-end and self-driving workflows.\nWhy it matters\nAutomation reduces friction in advanced experiments, improves repeatability, and enables higher-throughput scientific discovery.\nRepresentative result - Automated end-to-end ptychographic tomography\nCollaboration angle\nThis is particularly relevant for partners who want more robust acquisition, scalable pipelines, or autonomous microscopy workflows."
+  },
+  {
+    "objectID": "about.html#imprint",
+    "href": "about.html#imprint",
+    "title": "Imprint",
+    "section": "",
+    "text": "This website presents the ECLIPSE Lab and related research, teaching, and opportunity information.\nFor official institutional and contact details, please use the Contact page and the relevant Friedrich-Alexander University Erlangen-Nürnberg resources."
   }
 ]

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://pelzlab.science/research.html</loc>
-    <lastmod>2026-03-02T19:26:28.424Z</lastmod>
+    <lastmod>2026-03-17T21:05:16.943Z</lastmod>
   </url>
   <url>
     <loc>https://pelzlab.science/contact.html</loc>
@@ -70,7 +70,7 @@
   </url>
   <url>
     <loc>https://pelzlab.science/index.html</loc>
-    <lastmod>2026-03-09T21:06:44.294Z</lastmod>
+    <lastmod>2026-03-17T21:05:16.942Z</lastmod>
   </url>
   <url>
     <loc>https://pelzlab.science/hyperscale.html</loc>
@@ -174,7 +174,7 @@
   </url>
   <url>
     <loc>https://pelzlab.science/about.html</loc>
-    <lastmod>2026-03-02T19:26:28.019Z</lastmod>
+    <lastmod>2026-03-17T21:05:16.945Z</lastmod>
   </url>
   <url>
     <loc>https://pelzlab.science/people/staff/00_pelz_philipp.html</loc>
@@ -242,10 +242,10 @@
   </url>
   <url>
     <loc>https://pelzlab.science/license.html</loc>
-    <lastmod>2026-03-05T19:22:01.658Z</lastmod>
+    <lastmod>2026-03-17T21:05:16.946Z</lastmod>
   </url>
   <url>
     <loc>https://pelzlab.science/trademark.html</loc>
-    <lastmod>2026-03-05T19:22:01.660Z</lastmod>
+    <lastmod>2026-03-17T21:05:16.947Z</lastmod>
   </url>
 </urlset>

--- a/docs/trademark.html
+++ b/docs/trademark.html
@@ -83,11 +83,17 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 <link rel="stylesheet" href="styles.css">
 <meta property="og:title" content="Accessibility – ECLIPSE Lab">
 <meta property="og:description" content="">
+<meta property="og:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta property="og:site_name" content="ECLIPSE Lab">
+<meta property="og:image:height" content="554">
+<meta property="og:image:width" content="1080">
 <meta name="twitter:title" content="Accessibility – ECLIPSE Lab">
 <meta name="twitter:description" content="">
+<meta name="twitter:image" content="https://pelzlab.science/img/eclipse_header.png">
 <meta name="twitter:creator" content="@PhilippPelz">
-<meta name="twitter:card" content="summary">
+<meta name="twitter:image-height" content="554">
+<meta name="twitter:image-width" content="1080">
+<meta name="twitter:card" content="summary_large_image">
 </head>
 
 <body class="nav-fixed quarto-light">
@@ -130,6 +136,10 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   <li class="nav-item">
     <a class="nav-link" href="./research.html"> 
 <span class="menu-text">Research</span></a>
+  </li>  
+  <li class="nav-item">
+    <a class="nav-link" href="./research-by-problem.html"> 
+<span class="menu-text">By Problem</span></a>
   </li>  
   <li class="nav-item">
     <a class="nav-link" href="./publications.html"> 
@@ -182,7 +192,7 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   <li><a href="#feedback" id="toc-feedback" class="nav-link" data-scroll-target="#feedback">Feedback</a></li>
   </ul></li>
   </ul>
-</nav>
+<div class="toc-actions"><ul><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/blob/main/trademark.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></nav>
     </div>
 <!-- main -->
 <main class="content" id="quarto-document-content">
@@ -219,7 +229,7 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
 </section>
 <section id="known-limitations" class="level3">
 <h3 class="anchored" data-anchor-id="known-limitations">Known limitations</h3>
-<p>Some legacy content and embedded media may not fully meet current accessibility best practices.</p>
+<p>Some legacy content and embedded media may not yet fully meet current accessibility best practices.</p>
 </section>
 <section id="feedback" class="level3">
 <h3 class="anchored" data-anchor-id="feedback">Feedback</h3>
@@ -645,16 +655,16 @@ gtag('config', 'G-TVZKKP7YNR', { 'anonymize_ip': true});
   </li>  
     <li class="nav-item">
     <a class="nav-link" href="./license.html">
-<p>Privacy</p>
+<p>Privacy Notice</p>
 </a>
   </li>  
     <li class="nav-item">
     <a class="nav-link active" href="./trademark.html" aria-current="page">
-<p>Accessibility</p>
+<p>Accessibility Statement</p>
 </a>
   </li>  
 </ul>
-    </div>
+    <div class="toc-actions d-sm-block d-md-none"><ul><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/blob/main/trademark.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ECLIPSE-Lab/eclipse-lab.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div></div>
     <div class="nav-footer-right">
       &nbsp;
     </div>

--- a/index.qmd
+++ b/index.qmd
@@ -15,6 +15,36 @@ toc: false
   We develop computational tools to enable new capabilities in electron and X-ray microscopes and apply them to challenging materials science questions.
 :::
 
+## Start here
+
+If you are new to the lab, the shortest useful summary is this: we work on difficult imaging problems where better reconstruction, automation, and physically informed computation can unlock new scientific measurements.
+
+:::: {.columns}
+
+::: {.column width="33%"}
+### What problem are we solving?
+Modern microscopy often produces rich but difficult-to-interpret measurements. We develop methods that make 3D structure, chemistry, and weak signals more accessible at higher throughput and lower dose.
+
+[See research by problem](research-by-problem.qmd){.btn .btn-primary}
+:::
+
+::: {.column width="33%"}
+### Why does it matter now?
+Better algorithms and automation make it possible to extract more information from advanced microscopes while improving speed, sensitivity, and experimental reliability.
+
+[Explore research directions](research.qmd){.btn .btn-primary}
+:::
+
+::: {.column width="34%"}
+### Where should I go next?
+Whether you want to join the lab, collaborate on a project, or understand our current work, start with the pathways below.
+
+[Join the lab](opportunities.qmd){.btn .btn-primary .me-1}
+[Contact us](contact.qmd){.btn .btn-outline-secondary}
+:::
+
+::::
+
 ::: {.lead}
   Publication Highlights
 :::
@@ -63,7 +93,7 @@ toc: false
         <div>
           <a href="https://www.nature.com/articles/s41467-023-39304-9">Imaging the electron charge density in monolayer MoS2 at the Angstrom scale (Nat Comm 2023)</a>
 				</div>
-        <img src="img/charge_density.svg" alt="c">
+        <img src="img/charge_density.svg" alt="Imaging the electron charge density in monolayer MoS2 at the Angstrom scale">
       </li>
 
 		</ul>
@@ -89,12 +119,6 @@ toc: false
  
 </script>
 ```
-
-
-
-
-
-
 
 ::: {.lead}
   We are an [interdisciplinary]{.fw-bolder} research group based within the [Department of Materials Science](https://www.ww.tf.fau.de/){.text-primary .text-decoration-none .fw-semibold} at the [Friedrich-Alexander University of Erlangen-Nürnberg](https://www.fau.de/){.text-primary .text-decoration-none .fw-semibold}. We have expertise in [condensed matter physics, deep learning, large-scale optimization, signal and image processing, and experimental design]{.fw-bolder} for advanced [X-ray and electron microscopy]{.fw-bolder} experiments. 

--- a/license.qmd
+++ b/license.qmd
@@ -9,7 +9,7 @@ ECLIPSE Lab is committed to collecting as little personal data as possible.
 ### What we collect
 
 - Basic aggregated website analytics (Google Analytics) to understand overall site usage.
-- Information you voluntarily provide when contacting us (e.g., by email).
+- Information you voluntarily provide when contacting us (for example by email).
 
 ### What we do not do
 

--- a/research.qmd
+++ b/research.qmd
@@ -12,41 +12,69 @@ toc: true
 </nav>
 ```
 
-## Research Topics
+## Research
 
 Prefer a problem-first view? See [Research by Problem](research-by-problem.qmd).
 
-### Computational imaging
+## Capability areas
 
-- **Large-scale dose-efficient 3D imaging**
+### Computational imaging for difficult 3D measurements
 
-  We are leaders in the development of 3D imaging methods based on 4D-STEM measurements. 
+**What we build**  
+We develop 3D imaging methods based on 4D-STEM and related computational reconstruction pipelines for large-scale, dose-efficient, high-resolution measurements.
 
-    - [2023: first atomic-resolution 3D volume from 4D-STEM tomography](https://www.nature.com/articles/s41467-023-43634-z) 
-    - [2024: first atomic-resolution phase-contrast volume beyond the depth of focus limit](https://doi.org/10.1088/2515-7639/ad9ad2)
-    - [2024: first end-to-end reconstruction reaching sub-Angstrom resolution](https://doi.org/10.1088/1402-4896/ad9a1a)
+**Why it matters**  
+Many important materials problems require 3D information at high resolution, but conventional workflows remain too slow, too dose-intensive, or too limited for weakly scattering structures.
 
-  These methods will enable high-throughput, high-resolution, and high-sensitivity 3D imaging of large samples. Especially weakly scattering atoms can be resolved with unprecedented accuracy.
+**Representative results**
+- [2023: first atomic-resolution 3D volume from 4D-STEM tomography](https://www.nature.com/articles/s41467-023-43634-z)
+- [2024: first atomic-resolution phase-contrast volume beyond the depth of focus limit](https://doi.org/10.1088/2515-7639/ad9ad2)
+- [2024: first end-to-end reconstruction reaching sub-Angstrom resolution](https://doi.org/10.1088/1402-4896/ad9a1a)
 
-- **Fast simulators for electron microscopy** 
+**Collaboration angle**  
+We are interested in collaborations where new reconstruction methods can unlock 3D structure, chemistry, or sensitivity in experimentally challenging datasets.
 
-  We are developing fast simulators for electron microscopy.
+### Fast simulation and model-based electron microscopy
 
-  - [\>100x faster simulations](https://academic.oup.com/mam/article/27/4/835/6888048)
+**What we build**  
+We develop fast simulators and model-based workflows for electron microscopy that support method design, reconstruction, and quantitative interpretation.
+
+**Why it matters**  
+Simulation is essential for testing algorithms, understanding signal formation, and scaling new microscopy methods to realistic experiments.
+
+**Representative result**
+- [>100x faster simulations](https://academic.oup.com/mam/article/27/4/835/6888048)
+
+**Collaboration angle**  
+This is relevant for groups who need reliable forward models, synthetic benchmarks, or tighter coupling between experiment and computation.
 
 ### Multi-modal microscopy
 
+**What we build**  
 We are developing new approaches for multi-modal 3D imaging, down to the atomic scale.
 
-Stay tuned for the first results!
+**Why it matters**  
+Combining complementary signals can reveal structure, chemistry, and function more effectively than single-mode imaging alone.
 
-### Self-driving equipment
+**Current status**  
+Stay tuned for the first results.
 
-We are developing automation methods for electron microscopy.
+**Collaboration angle**  
+We welcome collaborations where multimodal data fusion or cross-signal interpretation is the limiting step.
 
-- [Automated End-to-end ptychographic tomography](https://doi.org/10.1093/mam/ozaf048.070)
+### Self-driving and automated microscopy
 
+**What we build**  
+We develop automation methods for electron microscopy, including end-to-end and self-driving workflows.
 
+**Why it matters**  
+Automation reduces friction in advanced experiments, improves repeatability, and enables higher-throughput scientific discovery.
+
+**Representative result**
+- [Automated end-to-end ptychographic tomography](https://doi.org/10.1093/mam/ozaf048.070)
+
+**Collaboration angle**  
+This is particularly relevant for partners who want more robust acquisition, scalable pipelines, or autonomous microscopy workflows.
 
 ## Research Funding
 
@@ -75,10 +103,10 @@ We are developing automation methods for electron microscopy.
 
 ## Research Framework
 
-### Holistic microscopy - using as much of the scattering information as possible
+### Holistic microscopy
 
-The substantive focus of our work is on incorporating prior physical knowledge about scattering mechanisms and multiple signal channels into the image reconstruction.
+The substantive focus of our work is on incorporating prior physical knowledge about scattering mechanisms and multiple signal channels into image reconstruction.
 
 ### ML-driven microscopy
 
-We use modern machine learning tools to make microscopy faster and better
+We use modern machine learning tools to make microscopy faster, more robust, and more informative.

--- a/trademark.qmd
+++ b/trademark.qmd
@@ -14,7 +14,7 @@ ECLIPSE Lab aims to make this website accessible and usable for all visitors.
 
 ### Known limitations
 
-Some legacy content and embedded media may not fully meet current accessibility best practices.
+Some legacy content and embedded media may not yet fully meet current accessibility best practices.
 
 ### Feedback
 


### PR DESCRIPTION
Implements all three selected website improvements:\n\n1. Adds a homepage "Start here" research-storytelling section\n2. Reframes the Research page into capability + evidence blocks\n3. Clarifies footer/legal information scent and labels\n\nAlso re-renders the affected Quarto output pages.