### PR TITLE
Add JSON-LD structured data (Organization + Person schema)

### DIFF
--- a/_includes/org-jsonld.html
+++ b/_includes/org-jsonld.html
@@ -1,0 +1,68 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://pelzlab.science/#organization",
+      "name": "ECLIPSE Lab",
+      "alternateName": "ECLIPSE Laboratory",
+      "url": "https://pelzlab.science",
+      "logo": "https://pelzlab.science/img/FAU.png",
+      "description": "ECLIPSE Lab at FAU Erlangen-Nürnberg focuses on computational materials microscopy, electron & X-ray imaging, autonomous microscopy systems, and large-scale inverse problems.",
+      "sameAs": [
+        "https://github.com/ECLIPSE-Lab",
+        "https://twitter.com/PhilippPelz"
+      ],
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "contactType": "Principal Investigator",
+        "url": "https://pelzlab.science/people/staff/00_pelz_philipp.html"
+      },
+      "memberOf": {
+        "@type": "Organization",
+        "name": "Friedrich-Alexander-Universität Erlangen-Nürnberg",
+        "alternateName": "FAU",
+        "url": "https://www.fau.de"
+      }
+    },
+    {
+      "@type": "Person",
+      "@id": "https://pelzlab.science/people/staff/00_pelz_philipp.html#person",
+      "name": "Philipp Pelz",
+      "alternateName": "Philipp",
+      "url": "https://pelzlab.science/people/staff/00_pelz_philipp.html",
+      "image": "https://pelzlab.science/img/eclipse_header.png",
+      "jobTitle": "W2 Professor (Tenure Track) for Computational Materials Microscopy",
+      "worksFor": {
+        "@id": "https://pelzlab.science/#organization"
+      },
+      "affiliation": {
+        "@type": "Organization",
+        "name": "FAU Erlangen-Nürnberg",
+        "url": "https://www.fau.de"
+      },
+      "sameAs": [
+        "https://orcid.org/0000-0002-8009-4515",
+        "https://scholar.google.de/citations?hl=en&user=d-lXKR8AAAAJ",
+        "https://www.webofscience.com/wos/author/record/JZT-3950-2024",
+        "https://www.scopus.com/authid/detail.uri?authorId=56005365900",
+        "https://github.com/PhilippPelz",
+        "https://twitter.com/PhilippPelz"
+      ],
+      "alumniOf": [
+        {
+          "@type": "Organization",
+          "name": "University of California, Berkeley",
+          "description": "Postdoctoral Researcher, 2019–2022"
+        },
+        {
+          "@type": "Organization",
+          "name": "Max Planck Institute for the Structure & Dynamics of Matter",
+          "description": "Ph.D. Researcher, 2013–2018"
+        }
+      ]
+    }
+  ]
+}
+</script>

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,6 +10,7 @@ execute:
     freeze: auto
 
 website:
+  include-in-header: _includes/org-jsonld.html
   title: "ECLIPSE Lab"  
   favicon: favicon-32x32.png
   open-graph: true


### PR DESCRIPTION
## What
Adds `Organization` and `Person` JSON-LD schema markup to every page of the ECLIPSE Lab website, improving Google rich snippets and search appearance for lab-related queries.

## Changes
- **`_includes/org-jsonld.html`** (new) — Organization schema for ECLIPSE Lab + Person schema for Dr. Philipp Pelz (PI), including affiliations, ORCID, Google Scholar, GitHub, Twitter links
- **`_quarto.yml`** — injects the partial via `include-in-header` so it appears in all rendered pages

## Testing
Validate the JSON-LD in browser DevTools → search for `application/ld+json`, or use [Google's Rich Results Test](https://search.google.com/test/rich-results) on any deployed page.