### PR TITLE
Add OG meta tags, canonical URLs + interactive type filter on publications

### DIFF
--- a/_includes/og-tags.html
+++ b/_includes/og-tags.html
@@ -1,0 +1,8 @@
+<!-- Open Graph + Twitter Card + Canonical URL meta tags -->
+<meta property="og:site_name" content="ECLIPSE Lab">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:creator" content="@PhilippPelz">
+<link rel="canonical" href="https://pelzlab.science{{ page_url }}">
+<meta property="og:description" content="{{ page_description | default('ECLIPSE Lab at FAU Erlangen-Nürnberg — computational materials microscopy, electron & X-ray imaging, autonomous microscopy, and large-scale inverse problems.') }}">
+<meta name="twitter:description" content="{{ page_description | default('ECLIPSE Lab at FAU Erlangen-Nürnberg — computational materials microscopy, electron & X-ray imaging, autonomous microscopy, and large-scale inverse problems.') }}">

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,7 +10,9 @@ execute:
     freeze: auto
 
 website:
-  include-in-header: _includes/org-jsonld.html
+  include-in-header:
+  - _includes/org-jsonld.html
+  - _includes/og-tags.html
   title: "ECLIPSE Lab"  
   favicon: favicon-32x32.png
   open-graph: true

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,7 @@
 ---
 pagetitle: "ECLIPSE Lab"
 title: ""
+description: "ECLIPSE Lab at FAU Erlangen-Nürnberg — computational materials microscopy, electron & X-ray imaging, autonomous systems, and large-scale inverse problems."
 toc: false
 ---
 

--- a/publications.qmd
+++ b/publications.qmd
@@ -1,5 +1,6 @@
 ---
 pagetitle: "Publications | ECLIPSE Lab"
+description: "Full list of publications from the ECLIPSE Lab — computational microscopy, ptychography, electron tomography, and related methods."
 toc: false
 listing:
   - id: articles
@@ -10,7 +11,7 @@ listing:
       - "year desc"
       - "title"
     sort-ui: [title,author,publication,year]
-    filter-ui: [title,author,publication,year]
+    filter-ui: [title,author,publication,year,type]
     page-size: 20
     field-display-names: 
       publication: "Publication"


### PR DESCRIPTION
## What

**#1 — Open Graph meta tags + canonical URLs**
Adds missing OG/Twitter Card meta tags to every page, and canonical URLs for SEO consolidation:
- `og:description`, `twitter:description` — populated from page `description` front-matter field (homepage + publications page now have explicit descriptions; all others get a sensible lab default)
- `og:url`, `canonical` — set from Quarto's `page_url` variable, preventing duplicate content issues
- `twitter:card: summary_large_image` — enables rich link previews on X/Twitter

**#3 — Interactive type filter on Publications page**
Added `type` to `filter-ui` on the publications listing so visitors can filter by publication type interactively alongside the existing year sort. The type field is populated from each article's `categories` taxonomy.

## Changes
- `_includes/og-tags.html` (new) — OG + Twitter Card + canonical meta partial
- `_quarto.yml` — inject both org-jsonld.html + og-tags.html via `include-in-header`
- `index.qmd` — add page description for OG
- `publications.qmd` — add page description + `type` to `filter-ui`

## Testing
- Validate OG tags: [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) or [OpenGraph Checker](https://opengraphcheck.com/)
- Validate rich cards: [X Card Validator](https://cards-dev.x.com/validator)
- Validate canonical: inspect any page source and search for `canonical`
- Publications filter: browse to https://pelzlab.science/publications.html and use the type dropdown