### PR TITLE
Add per-page meta descriptions for SEO

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Imprint"
+description: "Imprint and legal information for ECLIPSE Lab, headed by Prof. Philipp Pelz at Friedrich-Alexander-Universität Erlangen-Nürnberg."
+
 ---
 
 ## Imprint

--- a/contact.qmd
+++ b/contact.qmd
@@ -2,6 +2,8 @@
 pagetitle: "Contact | ECLIPSE Lab"
 toc: false
 email-obfuscation: javascript
+description: "Contact ECLIPSE Lab at FAU Erlangen-Nürnberg. Reach Prof. Philipp Pelz and the team for collaborations, questions, and visiting."
+
 ---
 
 ```{=html}

--- a/hyperscale.qmd
+++ b/hyperscale.qmd
@@ -1,6 +1,8 @@
 ---
 pagetitle: "ERC Starting Grant HyperScaleEM | ECLIPSE Lab"
 toc: true
+description: "HyperScaleEM — ERC Starting Grant project at ECLIPSE Lab developing next-generation autonomous electron microscopy with physics-informed AI."
+
 ---
 
 ## Vision of HyperScaleEM

--- a/index.qmd
+++ b/index.qmd
@@ -2,6 +2,8 @@
 pagetitle: "ECLIPSE Lab"
 title: ""
 toc: false
+description: "ECLIPSE Lab at FAU Erlangen-Nürnberg — computational materials microscopy, electron & X-ray imaging, autonomous microscopy systems, and large-scale inverse problems."
+
 ---
 
 ```{=html}

--- a/news.qmd
+++ b/news.qmd
@@ -7,6 +7,8 @@ listing:
   type: default
   categories: true
   max-items: 12
+description: "Latest news, conference presentations, and lab updates from ECLIPSE Lab at FAU Erlangen-Nürnberg."
+
 ---
 
 ```{=html}

--- a/opportunities.qmd
+++ b/opportunities.qmd
@@ -1,6 +1,8 @@
 ---
 pagetitle: "Join the Lab | ECLIPSE Lab"
 toc: true
+description: "Open PhD, MSc, BSc, and postdoctoral positions at ECLIPSE Lab, FAU Erlangen-Nürnberg. Join us in computational materials microscopy and electron imaging."
+
 ---
 
 ```{=html}

--- a/people.qmd
+++ b/people.qmd
@@ -64,6 +64,8 @@ listing:
       subtitle: "Role"
       started: "Started"
       ended: "Ended"
+description: "Meet the ECLIPSE Lab team at FAU Erlangen-Nürnberg — researchers, PhD students, and alumni working on computational microscopy and electron imaging."
+
 ---
 
 ```{=html}

--- a/publications.qmd
+++ b/publications.qmd
@@ -15,6 +15,8 @@ listing:
     field-display-names: 
       publication: "Publication"
       year: "Year"
+description: "Full list of publications from ECLIPSE Lab — computational microscopy, ptychography, electron tomography, and related methods."
+
 ---
 
 ```{=html}

--- a/research.qmd
+++ b/research.qmd
@@ -1,6 +1,8 @@
 ---
 pagetitle: "Research | ECLIPSE Lab"
 toc: true
+description: "Research areas of the ECLIPSE Lab: electron ptychography, atomic electron tomography, 4D-STEM imaging, autonomous microscopy, and computational image reconstruction."
+
 ---
 
 ```{=html}

--- a/resources.qmd
+++ b/resources.qmd
@@ -1,6 +1,8 @@
 ---
 pagetitle: "Resources | ECLIPSE Lab"
 toc: true
+description: "Resources from ECLIPSE Lab — microscopy datasets, software tools, and links for computational materials microscopy research."
+
 ---
 
 ```{=html}

--- a/teaching.qmd
+++ b/teaching.qmd
@@ -2,6 +2,8 @@
 pagetitle: "Teaching"
 toc: false
 email-obfuscation: javascript
+description: "Teaching materials and courses offered by Prof. Philipp Pelz at FAU Erlangen-Nürnberg, covering computational imaging and electron microscopy."
+
 ---
 
 ```{=html}


### PR DESCRIPTION
## What
Adds a `description` frontmatter field to all 11 key site pages. This feeds into:

- `<meta name="description">` in the rendered HTML `<head>`
- `og:description` via the `_includes/og-tags.html` partial (which uses `{{ page_description }}`)

Pages updated:
`index`, `research`, `publications`, `opportunities`, `people`, `about`, `contact`, `news`, `resources`, `teaching`, `hyperscale`

Each description is a concise 1–2 sentence summary that will appear as the snippet in Google search results and as the card description when shared on LinkedIn/Twitter.

## Testing
1. Render the site and inspect `<head>` of any page — look for `<meta name="description" content="...">`
2. Paste any page URL into [Google's Rich Results Test](https://search.google.com/test/rich-results) — description should appear in the preview