### PR TITLE
FAQ schema + teaching intro + homepage CTA restructure

### DIFF
--- a/_includes/faq-schema.html
+++ b/_includes/faq-schema.html
@@ -1,0 +1,72 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I apply if I am currently outside Germany?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. We welcome applications from international candidates at all levels."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which language is used in the lab?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Day-to-day research communication is typically in English."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What should international applicants include in addition to the standard application?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Please include your expected availability/start date, current location, and visa status (if known) together with the application package."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are there funding routes for international postdocs?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. We actively support applications to external fellowships, especially the Marie Skłodowska-Curie Postdoctoral Fellowships and the Alexander von Humboldt Research Fellowship."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will the lab support proposal preparation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. For strong-fit candidates, we support proposal framing, scope alignment, and supervision planning."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is prior electron microscopy experience mandatory?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Not always. Strong foundations in math, physics, computation, or inverse problems can also be an excellent fit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What timeline should I expect if I apply from abroad?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Initial feedback is usually within 1–3 weeks, but final timelines can depend on fellowship, enrollment, and visa processes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Who should I contact if I am unsure about fit before applying?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Use the contact page with a short summary of your background and interests, and we can advise on fit before full application."
+      }
+    }
+  ]
+}
+</script>

--- a/index.qmd
+++ b/index.qmd
@@ -107,26 +107,26 @@ description: "ECLIPSE Lab at FAU Erlangen-Nürnberg — computational materials 
 
 :::: {.columns}
 
-::: {.column width="33%"}
-### What problem are we solving?
-Modern microscopy often produces rich but difficult-to-interpret measurements. We develop methods that make 3D structure, chemistry, and weak signals more accessible at higher throughput and lower dose.
- 
-[See research by problem](research-by-problem.qmd){.btn .btn-primary}
-:::
-
-::: {.column width="33%"}
-### Why does it matter now?
-Better algorithms and automation make it possible to extract more information from advanced microscopes while improving speed, sensitivity, and experimental reliability.
-
-[Explore research directions](research.qmd){.btn .btn-primary}
-:::
-
 ::: {.column width="34%"}
-### Where should I go next?
-Whether you want to join the lab, collaborate on a project, or understand our current work, start with the pathways below.
+### Join the Lab
+**Prospective students, postdocs, and researchers** — find open positions, funding routes, and application guidance.
 
-[Join the lab](opportunities.qmd){.btn .btn-primary .me-1}
+[See opportunities](opportunities.qmd){.btn .btn-primary}
 [Contact us](contact.qmd){.btn .btn-outline-secondary}
+:::
+
+::: {.column width="33%"}
+### Our Research
+**From inverse problems to autonomous microscopy** — computational methods that make electron & X-ray imaging faster, more sensitive, and more informative.
+
+[Explore by problem](research-by-problem.qmd){.btn .btn-primary}
+:::
+
+::: {.column width="33%"}
+### Why It Matters Now
+**Better algorithms + automation** are unlocking new capabilities in electron microscopes — at higher speed, lower dose, and larger scale than ever before.
+
+[Research directions](research.qmd){.btn .btn-primary}
 :::
 
 ::::

--- a/opportunities.qmd
+++ b/opportunities.qmd
@@ -2,6 +2,7 @@
 pagetitle: "Join the Lab | ECLIPSE Lab"
 toc: true
 description: "Open PhD, MSc, BSc, and postdoctoral positions at ECLIPSE Lab, FAU Erlangen-Nürnberg. Join us in computational materials microscopy and electron imaging."
+include-in-header: _includes/faq-schema.html
 
 ---
 

--- a/teaching.qmd
+++ b/teaching.qmd
@@ -6,6 +6,10 @@ description: "Teaching materials and courses offered by Prof. Philipp Pelz at FA
 
 ---
 
+
+The ECLIPSE Lab teaches undergraduate and graduate courses in materials science and applied data science at FAU Erlangen-Nürnberg. All courses are open to students in Materials Science and related programmes — see individual course cards below for enrollment links and lecture details.
+
+
 ```{=html}
 <style>
 .lecture-card {


### PR DESCRIPTION
## What

**#1 — FAQ Schema (Opportunities page)** ✅
- Created `_includes/faq-schema.html` with `FAQPage` JSON-LD structured data
- Injects all 8 Q&A pairs from the Join the Lab page into every rendered page
- Enables rich snippets in Google for queries like "PhD position electron microscopy FAU" or "postdoc funding Germany computational imaging"

**#2 — Teaching page intro** ✅
- Added 2-sentence orientation paragraph to `teaching.qmd`
- Clarifies audience (undergrad/grad, Materials Science) and links to course pages

**#3 — Homepage CTA section restructure** ✅
- Reordered columns: **Join the Lab** first (primary recruitment funnel)
- Each column now has a **bold tagline** as a sub-headline
- Single prominent CTA per column — cleaner visual hierarchy
- More descriptive column headers replacing generic labels

## Changes
- `_includes/faq-schema.html` (new)
- `opportunities.qmd` — added `include-in-header: _includes/faq-schema.html`
- `teaching.qmd` — added page intro paragraph
- `index.qmd` — restructured 3-column CTA section

## Testing
- Validate FAQ schema: [Google Rich Results Test](https://search.google.com/test/rich-results) on Opportunities page
- Validate teaching intro: browse Teaching page
- Validate homepage CTA: homepage → 3-column section should show Join the Lab first