### PR TITLE
fix: remove incorrect gap-free claim from multi-modal microscopy section

### DIFF
--- a/research.qmd
+++ b/research.qmd
@@ -94,9 +94,6 @@ We are developing new approaches for multi-modal 3D imaging, down to the atomic 
 **Why it matters**  
 Combining complementary signals can reveal structure, chemistry, and function more effectively than single-mode imaging alone.
 
-**Current status**  
-We recently demonstrated gap-free, quantitative 3D structure retrieval at atomic resolution by fusing tilt-corrected dark-field and direct ptychography in 4D-STEM [(arXiv:2512.19460)](https://arxiv.org/abs/2512.19460), You et al., 2025). This approach overcomes the depth-of-focus limitation of conventional ADF tomography, enabling truly gap-free information transfer across spatial frequencies.
-
 **Collaboration angle**  
 We welcome collaborations where multimodal data fusion or cross-signal interpretation is the limiting step.
 


### PR DESCRIPTION
Removed the incorrect 'Current status' paragraph that falsely attributed the gap-free 3D result to arXiv:2512.19460 (You et al., 2025).